### PR TITLE
Signature of `Callback.on_train_epoch_end` has changed in v1.3. `outp…

### DIFF
--- a/mingpt/callback.py
+++ b/mingpt/callback.py
@@ -13,7 +13,7 @@ class CUDACallback(Callback):
         torch.cuda.synchronize(trainer.root_gpu)
         self.start_time = time.time()
 
-    def on_train_epoch_end(self, trainer, pl_module, outputs):
+    def on_train_epoch_end(self, trainer, pl_module):
         torch.cuda.synchronize(trainer.root_gpu)
         max_memory = torch.cuda.max_memory_allocated(trainer.root_gpu) / 2 ** 20
         epoch_time = time.time() - self.start_time


### PR DESCRIPTION
…uts` parameter has been removed.